### PR TITLE
Improved the `LDAP.STATUS` command

### DIFF
--- a/src/vkldap/server.rs
+++ b/src/vkldap/server.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use url::Url;
 
 #[derive(Clone)]
@@ -26,11 +28,17 @@ pub struct VkLdapServer {
     url: Url,
     id: usize,
     status: VkLdapServerStatus,
+    ping_time: Option<Duration>,
 }
 
 impl VkLdapServer {
     pub(super) fn new(url: Url, id: usize, status: VkLdapServerStatus) -> VkLdapServer {
-        VkLdapServer { url, id, status }
+        VkLdapServer {
+            url,
+            id,
+            status,
+            ping_time: None,
+        }
     }
 
     pub(super) fn get_url_ref(&self) -> &Url {
@@ -58,5 +66,13 @@ impl VkLdapServer {
 
     pub(super) fn set_status(&mut self, status: VkLdapServerStatus) {
         self.status = status
+    }
+
+    pub(super) fn set_ping_time(&mut self, ping_time: Option<Duration>) {
+        self.ping_time = ping_time
+    }
+
+    pub fn get_ping_time(&self) -> Option<Duration> {
+        self.ping_time
     }
 }

--- a/test/integration/util.py
+++ b/test/integration/util.py
@@ -59,3 +59,17 @@ class LdapTestCase(TestCase):
     def tearDown(self):
         self.vk.close()
         self.vk = None
+
+
+def valkey_map_to_python_map(valkey_map):
+    def _to_python_value(vk_value):
+        if isinstance(vk_value, list):
+            return valkey_map_to_python_map(vk_value)
+        else:
+            return vk_value.decode('utf-8')
+
+    python_map = {}
+    for i in range(0, len(valkey_map), 2) :
+        python_map[valkey_map[i].decode('utf-8')] = _to_python_value(valkey_map[i + 1])
+
+    return python_map


### PR DESCRIPTION
This commit improves the `LDAP.STATUS` command by restructuring the output of the command, and also by adding the ping time for each LDAP server.

The new output is map with the following structure:

```
{
  "server1_hostname": {
    "status": "healthy",
    "ping_time(ms)": "1.23"
  },
  "server2_hostname": {
    "status": "unhealthy",
    "error": "an error message"
  }

```