### PR TITLE
Hide search bind password when looking at the configuration

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -98,12 +98,29 @@ lazy_static! {
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
     pub static ref LDAP_SEARCH_BIND_DN: ValkeyGILGuard<ValkeyString> =
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
-    pub static ref LDAP_SEARCH_BIND_PASSWD: ValkeyGILGuard<ValkeyString> =
+    pub static ref LDAP_SEARCH_BIND_SHADOW_PASSWD: ValkeyGILGuard<ValkeyString> =
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
     pub static ref LDAP_SEARCH_DN_ATTRIBUTE: ValkeyGILGuard<ValkeyString> =
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
     pub static ref LDAP_CONNECTION_POOL_SIZE: ValkeyGILGuard<i64> = ValkeyGILGuard::new(2);
     pub static ref LDAP_FAILURE_DETECTOR_INTERVAL: ValkeyGILGuard<i64> = ValkeyGILGuard::new(1);
+}
+
+lazy_static! {
+    static ref LDAP_SEARCH_BIND_PASSWD: ValkeyGILGuard<ValkeyString> =
+        ValkeyGILGuard::new(ValkeyString::create(None, ""));
+}
+
+pub fn on_password_config_set<G, T: ConfigurationValue<ValkeyString>>(
+    ctx: &ConfigurationContext,
+    name: &str,
+    val: &'static T,
+) -> Result<(), ValkeyError> {
+    LDAP_SEARCH_BIND_PASSWD.set(ctx, val.get(ctx))?;
+
+    refresh_ldap_settings_cache(ctx, name, val);
+
+    val.set(ctx, ValkeyString::create(None, "*********"))
 }
 
 pub fn refresh_ldap_settings_cache<G, T: ConfigurationValue<G>>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod vkldap;
 
 use log::error;
 use valkey_module::{
-    Context, Status, ValkeyString, configuration::ConfigurationFlags,
+    Context, Status, ValkeyGILGuard, ValkeyString, configuration::ConfigurationFlags,
     logging::standard_log_implementation, valkey_module,
 };
 
@@ -158,10 +158,11 @@ valkey_module! {
             ],
             [
                 "search_bind_passwd",
-                &*configs::LDAP_SEARCH_BIND_PASSWD,
+                &*configs::LDAP_SEARCH_BIND_SHADOW_PASSWD,
                 "",
-                ConfigurationFlags::DEFAULT,
-                Some(Box::new(configs::refresh_ldap_settings_cache))
+                ConfigurationFlags::SENSITIVE,
+                None,
+                Some(Box::new(configs::on_password_config_set::<ValkeyString, ValkeyGILGuard<ValkeyString>>))
             ],
             [
                 "search_dn_attribute",

--- a/test/integration/test_ldap.py
+++ b/test/integration/test_ldap.py
@@ -67,11 +67,12 @@ class LdapModuleBindAndSearchTest(LdapTestCase):
 
         self.vk.execute_command("CONFIG", "SET", "ldap.auth_mode", "search+bind")
 
-        self.vk.execute_command("CONFIG", "SET", "ldap.search_base", "dc=valkey,dc=io")
         self.vk.execute_command(
             "CONFIG", "SET", "ldap.search_bind_dn", "cn=admin,dc=valkey,dc=io"
         )
         self.vk.execute_command("CONFIG", "SET", "ldap.search_bind_passwd", "admin123!")
+
+        self.vk.execute_command("CONFIG", "SET", "ldap.search_base", "dc=valkey,dc=io")
 
     def test_ldap_auth(self):
         self.vk.execute_command("AUTH", "u2", "user2@123")
@@ -88,6 +89,10 @@ class LdapModuleBindAndSearchTest(LdapTestCase):
         self.vk.execute_command("CONFIG", "SET", "ldap.servers", "ldaps://ldap")
         with self.assertRaises(AuthenticationError) as ctx:
             self.vk.execute_command("AUTH", "user2", "user2@123")
+
+    def test_ldap_bind_password_hidden(self):
+        res = self.vk.execute_command("CONFIG", "GET", "ldap.search_bind_passwd")
+        self.assertEqual(res[1].decode("utf-8"), "*********")
 
 
 class LdapModuleFailoverTest(LdapTestCase):


### PR DESCRIPTION
This commit implements a strategy to hide the password stored in the `ldap.search_bind_passwd` configuration option, which shows up when running a `CONFIG GET` command.

To hide the password, we cache the value set to
`ldap.search_bind_passwd` in our internal data structure and replace the value of `ldap.search_bind_passwd` by `*******`. This way it will only show `********` when running the `CONFIG GET` command.