### PR TITLE
Update list of `LdapError`s that are considered to be `VkLdapError::LdapConnectionError`

### DIFF
--- a/src/vkldap/errors.rs
+++ b/src/vkldap/errors.rs
@@ -111,7 +111,6 @@ impl VkLdapError {
             | LdapError::FilterParsing
             | LdapError::DecodingUTF8
             | LdapError::InvalidScopeString(_)
-            | LdapError::EndOfStream
             | LdapError::AddNoValues
             | LdapError::AdapterInit(_) => false,
             _ => true,


### PR DESCRIPTION
The `LdapError::EndOfStream` error happens when the connection to the LDAP server is closed during an LDAP operation like `search`. Therefore, we should consider this error as a connection error in order to failover the operation to the next available LDAP server.

This change fixes the flakiness of integration tests.