### PR TITLE
Add configurable LDAP connection and operation timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ After creating the above user `bob` in Valkey, it will only be possible to authe
 | ------------|------|---------|-------------|
 | `ldap.connection_pool_size` | number | `2` | The number of connections available in each LDAP server's connection pool. |
 | `ldap.failure_detector_interval` | number | `1` | The number of seconds between each iteration of the failure detector. |
+| `ldap.timeout_connection` | number | `10` | The number of seconds for to wait when connection to an LDAP server before timing out. |
+| `ldap.timeout_ldap_operation` | number | `10` | The number of seconds for to wait for an LDAP operation before timing out. |
 
 ## Installation
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,4 +1,5 @@
 use std::collections::LinkedList;
+use std::time::Duration;
 
 use lazy_static::lazy_static;
 use valkey_module::{
@@ -104,6 +105,8 @@ lazy_static! {
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
     pub static ref LDAP_CONNECTION_POOL_SIZE: ValkeyGILGuard<i64> = ValkeyGILGuard::new(2);
     pub static ref LDAP_FAILURE_DETECTOR_INTERVAL: ValkeyGILGuard<i64> = ValkeyGILGuard::new(1);
+    pub static ref LDAP_TIMEOUT_CONNECTION: ValkeyGILGuard<i64> = ValkeyGILGuard::new(10);
+    pub static ref LDAP_TIMEOUT_LDAP_OPERATION: ValkeyGILGuard<i64> = ValkeyGILGuard::new(10);
 }
 
 lazy_static! {
@@ -122,6 +125,7 @@ pub fn refresh_ldap_settings_cache<T: ValkeyLockIndicator>(ctx: &T) {
         get_search_bind_dn(ctx),
         get_search_bind_passwd(ctx),
         get_search_dn_attribute(ctx),
+        get_timeout_ldap_operation(ctx),
     );
     vkldap::refresh_ldap_settings(settings);
 }
@@ -133,6 +137,7 @@ pub fn refresh_connection_settings_cache<T: ValkeyLockIndicator>(ctx: &T) {
         get_tls_cert_path(ctx),
         get_tls_key_path(ctx),
         get_connection_pool_size(ctx),
+        get_timeout_connection(ctx),
     );
     vkldap::refresh_connection_settings(settings);
 }
@@ -342,4 +347,14 @@ pub fn get_connection_pool_size<T: ValkeyLockIndicator>(ctx: &T) -> usize {
 pub fn get_failure_detector_interval_secs<T: ValkeyLockIndicator>(ctx: &T) -> u64 {
     let interval = LDAP_FAILURE_DETECTOR_INTERVAL.lock(ctx);
     *interval as u64
+}
+
+pub fn get_timeout_connection<T: ValkeyLockIndicator>(ctx: &T) -> Duration {
+    let timeout = LDAP_TIMEOUT_CONNECTION.lock(ctx);
+    Duration::from_secs(*timeout as u64)
+}
+
+pub fn get_timeout_ldap_operation<T: ValkeyLockIndicator>(ctx: &T) -> Duration {
+    let timeout = LDAP_TIMEOUT_LDAP_OPERATION.lock(ctx);
+    Duration::from_secs(*timeout as u64)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,24 @@ valkey_module! {
                 std::i64::MAX,
                 ConfigurationFlags::DEFAULT,
                 Some(Box::new(configs::failure_detector_interval_changed))
+            ],
+            [
+                "timeout_connection",
+                &*configs::LDAP_TIMEOUT_CONNECTION,
+                10,
+                0,
+                std::i64::MAX,
+                ConfigurationFlags::DEFAULT,
+                Some(Box::new(configs::on_connection_setting_change))
+            ],
+            [
+                "timeout_ldap_operation",
+                &*configs::LDAP_TIMEOUT_LDAP_OPERATION,
+                10,
+                0,
+                std::i64::MAX,
+                ConfigurationFlags::DEFAULT,
+                Some(Box::new(configs::on_ldap_setting_change))
             ]
         ],
         string: [

--- a/src/vkldap/settings.rs
+++ b/src/vkldap/settings.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use ldap3::Scope;
 
 use crate::configs::LdapSearchScope;
@@ -23,6 +25,7 @@ pub struct VkLdapSettings {
     pub search_bind_dn: Option<String>,
     pub search_bind_passwd: Option<String>,
     pub search_dn_attribute: String,
+    pub timeout_ldap_operation: Duration,
 }
 
 impl VkLdapSettings {
@@ -36,6 +39,7 @@ impl VkLdapSettings {
         search_bind_dn: Option<String>,
         search_bind_passwd: Option<String>,
         search_dn_attribute: String,
+        timeout_ldap_operation: Duration,
     ) -> Self {
         Self {
             bind_db_prefix,
@@ -47,6 +51,7 @@ impl VkLdapSettings {
             search_bind_dn,
             search_bind_passwd,
             search_dn_attribute,
+            timeout_ldap_operation,
         }
     }
 }
@@ -63,6 +68,7 @@ impl Default for VkLdapSettings {
             search_bind_dn: Default::default(),
             search_bind_passwd: Default::default(),
             search_dn_attribute: Default::default(),
+            timeout_ldap_operation: Default::default(),
         }
     }
 }
@@ -74,6 +80,7 @@ pub struct VkConnectionSettings {
     pub client_cert_path: Option<String>,
     pub client_key_path: Option<String>,
     pub connection_pool_size: usize,
+    pub timeout_connection: Duration,
 }
 
 impl VkConnectionSettings {
@@ -83,6 +90,7 @@ impl VkConnectionSettings {
         client_cert_path: Option<String>,
         client_key_path: Option<String>,
         connection_pool_size: usize,
+        timeout_connection: Duration,
     ) -> Self {
         Self {
             use_starttls,
@@ -90,6 +98,7 @@ impl VkConnectionSettings {
             client_cert_path,
             client_key_path,
             connection_pool_size,
+            timeout_connection,
         }
     }
 }
@@ -102,6 +111,7 @@ impl Default for VkConnectionSettings {
             client_cert_path: Default::default(),
             client_key_path: Default::default(),
             connection_pool_size: 0,
+            timeout_connection: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This commit introduces two new configuration options, `ldap.timeout_connection` and `ldap.timeout_ldap_operation`, that control the timeout value for when connecting to an LDAP server, and when performing an LDAP operation.