### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/cargo-format.yml
+++ b/.github/workflows/cargo-format.yml
@@ -2,6 +2,8 @@ name: Rust Format Check
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     paths:
       - 'src/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - 'src/**'
+      - 'test/unit'
+      - 'test/integration'
 
 jobs:
     build:

--- a/.github/workflows/release_packaging.yml
+++ b/.github/workflows/release_packaging.yml
@@ -3,7 +3,7 @@ name: Release Packaging
 on:
   push:
     tags:
-        -'v*'
+        - 'v*'
 
 jobs:
   Create_RPM_Package:
@@ -13,7 +13,7 @@ jobs:
       image: fedora:41
     steps:
         - name: Checkout code
-          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+          uses: actions/checkout@v4
 
         - name: Install dependencies
           shell: bash
@@ -43,3 +43,37 @@ jobs:
           run : |
             SRPM=`ls valkey-ldap*.rpm`
             copr-cli --config copr.config build valkey-ldap $SRPM
+
+  Create_GitHub_Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Extract version from tag
+        id: extract_version
+        run: |
+          VERSION="${GITHUB_REF##*/}"
+          VERSION="${VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          CHANGELOG=$(./scripts/extract_changelog.sh "${{ steps.extract_version.outputs.VERSION }}")
+          echo "log<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.extract_version.outputs.VERSION }}
+          body: ${{ steps.changelog.outputs.log }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valkey-ldap"
-version = "0.0.1-dev"
+version = "1.0.0-dev"
 dependencies = [
  "const-str",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "valkey-ldap"
 authors = ["Ricardo Dias"]
-version = "0.0.1-dev"
+version = "1.0.0-dev"
 edition = "2024"
 build = "build.rs"
 license = "BSD-3-Clause"

--- a/HOWTORELEASE.md
+++ b/HOWTORELEASE.md
@@ -1,0 +1,60 @@
+# Release Procedure
+
+## General steps to cut a release from the main branch
+
+These are the steps to make a release candidate for version `X.X.0`:
+
+1. Make sure you are working on the current tip of the main branch.
+2. Update version string in `Cargo.toml` from `version = "X.X.0-dev"` to `version = "X.X.0-rc1"`.
+3. Update version hex number in the unit test of `src/versions.rs`.
+4. Review the changelog file `CHANGELOG.md` and check if all important changes are described in there.
+   - Create a new section `[X.X.0-rc1] - <YYYY-MM-DD>` and move all entries
+     from the `[Unreleased]` section to the new section.
+   - Make sure all github issues resolved in this release are referenced in the changelog.
+   - Update the links at the bottom of the file:
+
+```
+[unreleased]: https://github.com/valkey-io/valkey-ldap/compare/vX.X.0-rc1...HEAD
+[X.X.0]: https://github.com/valkey-io/valkey-ldap/releases/tag/vX.X.0-rc1
+```
+
+6. Run `cargo test --features enable-system-alloc` to check that versions match and to update `Cargo.lock` file.
+7. Create a commit with title `Bump to vX.X.0-rc1` containing the modifications made in the previous steps.
+8. Create a branch with name `X.X` and switch to that branch.
+8. Create an annotated tag for the above commit: `git tag -s -a vX.X.0-rc1 -m"version X.X.0-rc1"`.
+9. Push commit and tag to github repo: `git push <remote> X.X --tags`
+   - This will trigger a GitHub action that will create a draft release for version `X.X.0-rc1` and trigger the RPMs build in Copr.
+10. Switch back to the main branch.
+11. Update version string in `Cargo.toml` from `version = "X.X.0-rc1"` to `version = "Y.Y.0-dev"` where `Y.Y.0 > X.X.0`.
+12. Update version hex number in the unit test of `src/versions.rs`.
+13. Create a commit with title `Begin of vY.Y.0 development` containing the modifications made in the previous two steps and push it to the remote main branch.
+14. Review the GitHub release draft and publish the release when ready.
+
+
+## Steps for releasing GA version
+
+Assuming that version `X.X.0-rc1` has been cut of the main branch. To create the GA release follow the steps:
+
+1. Make sure you are working on the current tip of the `X.X` branch.
+2. Update version string in `Cargo.toml` from `version = "X.X.0-rc1"` to `version = "X.X.0"`.
+3. Update version hex number in the unit test of `src/versions.rs`.
+4. Review the changelog file `CHANGELOG.md` and check if all important changes are described in there.
+   - Create a new section `[X.X.0] - <YYYY-MM-DD>` and move all entries
+     from the `[Unreleased]` section to the new section.
+   - Make sure all github issues resolved in this release are referenced in the changelog.
+   - Update the links at the bottom of the file:
+
+```
+[unreleased]: https://github.com/valkey-io/valkey-ldap/compare/vX.X.0...HEAD
+[X.X.0]: https://github.com/valkey-io/valkey-ldap/releases/tag/vX.X.0
+[X.X.0_rc1]: https://github.com/valkey-io/valkey-ldap/releases/tag/vX.X.0-rc1
+```
+
+5. Create a commit with title `Bump to vX.X.0` containing the modifications made in the previous steps.
+6. Create an annotated tag for the above commit: `git tag -s -a vX.X.0 -m"version X.X.0"`.
+7. Push commit and tag to github repo: `git push <remote> X.X --tags`
+   - This will trigger a GitHub action that will create a draft release for version `X.X.0` and trigger the RPMs build in Copr.
+
+## Steps for doing patch releases
+
+Same has the steps for releasing the GA version by increasing the patch version number of the version string.

--- a/scripts/extract_changelog.sh
+++ b/scripts/extract_changelog.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+
+while [[ ! $PWD/ = */valkey-ldap/ ]]; do
+    cd ..
+done
+
+
+VERSION="$1"
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version>"
+    exit 1
+fi
+
+awk -v pattern="^## \\\[$VERSION\\\]" '$0 ~ pattern {flag=1; next} flag && $0 ~ "^## \\[" {flag=0} flag {print}' CHANGELOG.md
+

--- a/src/version.rs
+++ b/src/version.rs
@@ -35,9 +35,10 @@ pub const fn module_version() -> i32 {
     const PARTS: [&str; 3] = const_str::split!(MODULE_VERSION, ".");
     let major: i32 = const_str::parse!(PARTS[0], i32);
     let minor: i32 = const_str::parse!(PARTS[1], i32);
+    const IS_DEV: bool = const_str::contains!(PARTS[2], "-");
 
-    let (patch, dev) = if const_str::contains!(PARTS[2], "-") {
-        let patch_parts: [&str; 2] = const_str::split!(PARTS[2], "-");
+    let (patch, dev) = if IS_DEV {
+        let patch_parts = const_str::split!(PARTS[2], "-");
         let patch = const_str::parse!(patch_parts[0], i32);
         let dev = if const_str::equal!(patch_parts[1], "dev") {
             1
@@ -61,6 +62,6 @@ mod tests {
 
     #[test]
     fn test_version() {
-        assert_eq!(module_version(), 0x00000101);
+        assert_eq!(module_version(), 0x01000001);
     }
 }


### PR DESCRIPTION
This commit introduces the instructions for making releases of this module.

It improves the GitHub action workflow to create the GitHub release automatically based on the changelog present in the repository.

The instructions for the release manager to follow are present in `HOWTORELEASE.md` file.

This commit also changes the version of the module to `1.0.0-dev` to match the new release process rules.