### PR TITLE
Replaced `LDAP.STATUS` command by INFO section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_syn"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0ca8adcbd02c69d24859f7f0c54ede988e4509c8767c8a3185ec0eb158281c"
+dependencies = [
+ "bitflags 1.3.2",
+ "proc-macro2",
+ "serde",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1222,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "ldap3",
+ "linkme",
  "log",
  "native-tls",
  "paste",
@@ -1217,6 +1230,7 @@ dependencies = [
  "tokio",
  "url",
  "valkey-module",
+ "valkey-module-macros",
 ]
 
 [[package]]
@@ -1241,6 +1255,19 @@ dependencies = [
  "serde",
  "strum_macros",
  "valkey-module-macros-internals",
+]
+
+[[package]]
+name = "valkey-module-macros"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5017b4ecb384e2937d66f375571c9b8cbbdee1a73a1fcd281e542041d807b76"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.40",
+ "serde",
+ "serde_syn",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ rand = "0.9.1"
 const-str = "0.6.2"
 futures = "0.3.31"
 tokio = {version="1.45.0", features=["rt", "rt-multi-thread", "macros"]}
+valkey-module-macros = "0.1.9"
+linkme = "0.3.33"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ use valkey_module::{
 };
 
 use auth::ldap_auth_blocking_callback;
-use commands::ldap_status_command;
 use version::module_version;
 use vkldap::failure_detector;
 use vkldap::scheduler;
@@ -68,9 +67,7 @@ valkey_module! {
     auth: [
         ldap_auth_blocking_callback
     ],
-    commands: [
-        ["ldap.status", ldap_status_command, "readonly", 0, 0, 0],
-    ],
+    commands: [],
     configurations: [
         i64: [
             [

--- a/src/vkldap/server.rs
+++ b/src/vkldap/server.rs
@@ -41,19 +41,12 @@ impl VkLdapServer {
         }
     }
 
-    pub(super) fn get_url_ref(&self) -> &Url {
+    pub fn get_url_ref(&self) -> &Url {
         &self.url
     }
 
     pub(super) fn get_id(&self) -> usize {
         self.id
-    }
-
-    pub fn get_host_string(&self) -> String {
-        match self.url.host() {
-            Some(host) => host.to_string(),
-            None => self.url.to_string(),
-        }
     }
 
     pub(super) fn is_healthy(&self) -> bool {


### PR DESCRIPTION
In this commit we remove the `LDAP.STATUS` in favor of adding a new section to the `INFO` command to show the same information about the LDAP servers' connection health.

The new section is named `ldap_status` and it's content is a set of dictionaries, one per LDAP server, and in each dictionary, we have the `url`, `status`, `ping_time`, and `error` fields.

Example of the output:

```
 > INFO ldap
 # ldap_status
 ldap_server_0:url=ldap://ldap,status=unhealthy,error=LDAP connection failure: op send error: channel closed
 ldap_server_1:url=ldap://ldap-2,status=healthy,ping_time(ms)=1.645
```