### PR TITLE
Run integration tests against several Valkey versions with ASAN enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,43 +11,45 @@ on:
       - 'test/integration'
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        valkey_version: ["7.2", "8.0", "8.1"]
+    env:
+      PYTHONUNBUFFERED: 1
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libssl-dev libldap-dev netcat-traditional docker-compose ldap-utils
 
-            - name: Install dependencies
-              run: |
-                sudo apt-get update -y
-                sudo apt-get install -y libssl-dev libldap-dev netcat-traditional docker-compose ldap-utils
-            - name: Set up Python
-              uses: actions/setup-python@v3
-              with:
-                python-version: '3.13'
-            - name: Install Python test dependencies
-              run: |
-                python -m pip install --upgrade pip
-                pip install -r test/integration/requirements.txt
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
 
-            - name: Build Module
-              run: |
-                cargo build
+      - name: Install Python test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test/integration/requirements.txt
 
-            - name: Start Valkey and LDAP services
-              run: |
-                ./scripts/start_valkey_ldap.sh
+      - name: Build Rust module
+        run: cargo build
 
-            - name: Run Unit Tests
-              run: |
-                cargo test --features enable-system-alloc
+      - name: Start Valkey and LDAP services
+        run: ./scripts/start_valkey_ldap.sh ${{ matrix.valkey_version }}
 
-            - name: Run Integration Tests
-              run: |
-                python3 -m pytest -v test/integration
+      - name: Run Unit Tests
+        run: cargo test --features enable-system-alloc
 
-            - name: Stop Valkey and LDAP services
-              run: |
-                ./scripts/stop_valkey_ldap.sh
+      - name: Run Integration Tests
+        run: python3 -m pytest -v test/integration
+
+      - name: Stop Valkey and LDAP services
+        if: always()
+        run: ./scripts/stop_valkey_ldap.sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote 1.0.40",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1240,7 @@ dependencies = [
  "native-tls",
  "paste",
  "rand",
+ "strum_macros 0.27.1",
  "tokio",
  "url",
  "valkey-module",
@@ -1253,7 +1267,7 @@ dependencies = [
  "paste",
  "regex",
  "serde",
- "strum_macros",
+ "strum_macros 0.26.4",
  "valkey-module-macros-internals",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ futures = "0.3.31"
 tokio = {version="1.45.0", features=["rt", "rt-multi-thread", "macros"]}
 valkey-module-macros = "0.1.9"
 linkme = "0.3.33"
+strum_macros = "0.27.1"

--- a/scripts/docker/Dockerfile-valkey-ldap
+++ b/scripts/docker/Dockerfile-valkey-ldap
@@ -1,8 +1,0 @@
-FROM fedora:41
-
-VOLUME [ "/valkey-ldap" ]
-
-RUN yum -y install valkey openldap
-
-WORKDIR /valkey-ldap
-CMD [ "valkey-server", "./valkey.conf" ]

--- a/scripts/docker/Dockerfile-valkey-ldap-7.2
+++ b/scripts/docker/Dockerfile-valkey-ldap-7.2
@@ -1,0 +1,15 @@
+FROM debian:12
+
+VOLUME [ "/valkey-ldap" ]
+
+RUN apt update
+RUN apt install -y openssl git make clang build-essential libssl-dev
+
+RUN git clone -b 7.2 --single-branch https://github.com/valkey-io/valkey.git
+RUN cd valkey && \
+    make -j$(nproc) SANITIZER=address OPTIMIZATION=-g3 && \
+    make install
+
+WORKDIR /valkey-ldap
+
+CMD [ "valkey-server", "./valkey.conf" ]

--- a/scripts/docker/Dockerfile-valkey-ldap-8.0
+++ b/scripts/docker/Dockerfile-valkey-ldap-8.0
@@ -1,0 +1,14 @@
+FROM debian:12
+
+VOLUME [ "/valkey-ldap" ]
+
+RUN apt update
+RUN apt install -y openssl git make clang build-essential libssl-dev
+
+RUN git clone -b 8.0 --single-branch https://github.com/valkey-io/valkey.git
+RUN cd valkey && \
+    make -j$(nproc) SANITIZER=address OPTIMIZATION=-g3 && \
+    make install
+
+WORKDIR /valkey-ldap
+CMD [ "valkey-server", "./valkey.conf" ]

--- a/scripts/docker/Dockerfile-valkey-ldap-8.1
+++ b/scripts/docker/Dockerfile-valkey-ldap-8.1
@@ -1,0 +1,14 @@
+FROM debian:12
+
+VOLUME [ "/valkey-ldap" ]
+
+RUN apt update
+RUN apt install -y openssl git make clang build-essential libssl-dev
+
+RUN git clone -b 8.1 --single-branch https://github.com/valkey-io/valkey.git
+RUN cd valkey && \
+    make -j$(nproc) SANITIZER=address OPTIMIZATION=-g3 && \
+    make install
+
+WORKDIR /valkey-ldap
+CMD [ "valkey-server", "./valkey.conf" ]

--- a/scripts/docker/docker-compose.yaml
+++ b/scripts/docker/docker-compose.yaml
@@ -2,6 +2,7 @@ name: valkey-ldap
 services:
   ldap:
     image: osixia/openldap:1.5.0
+    profiles: ["valkey-7.2", "valkey-8.0", "valkey-8.1"]
     container_name: ldap
     environment:
         - LDAP_ORGANISATION=valkey
@@ -19,6 +20,7 @@ services:
 
   ldap-2:
     image: osixia/openldap:1.5.0
+    profiles: ["valkey-7.2", "valkey-8.0", "valkey-8.1"]
     container_name: ldap-2
     environment:
         - LDAP_ORGANISATION=valkey
@@ -34,15 +36,42 @@ services:
     volumes:
         - ./certs:/container/service/slapd/assets/certs
 
-  valkey:
+  valkey-7.2:
+    hostname: valkey
     build:
-      dockerfile: Dockerfile-valkey-ldap
+      dockerfile: Dockerfile-valkey-ldap-7.2
       context: ./
-    image: valkey-ldap
+    image: valkey-ldap-7.2
+    profiles: ["valkey-7.2"]
     container_name: valkey
     ports:
         - 6379:6379
     volumes:
         - ../../target/debug:/valkey-ldap
 
+  valkey-8.0:
+    hostname: valkey
+    build:
+      dockerfile: Dockerfile-valkey-ldap-8.0
+      context: ./
+    image: valkey-ldap-8.0
+    profiles: ["valkey-8.0"]
+    container_name: valkey
+    ports:
+        - 6379:6379
+    volumes:
+        - ../../target/debug:/valkey-ldap
+
+  valkey-8.1:
+    hostname: valkey
+    build:
+      dockerfile: Dockerfile-valkey-ldap-8.1
+      context: ./
+    image: valkey-ldap-8.1
+    profiles: ["valkey-8.1"]
+    container_name: valkey
+    ports:
+        - 6379:6379
+    volumes:
+        - ../../target/debug:/valkey-ldap
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -11,7 +11,8 @@ DOCKER_COMPOSE_RUNNING=`docker compose ls --filter name=valkey-ldap -q && true`
 STOP_SERVERS=
 
 if [ -z $DOCKER_COMPOSE_RUNNING ]; then
-    ./scripts/start_valkey_ldap.sh
+    ./scripts/start_valkey_ldap.sh $*
+    shift
     STOP_SERVERS=true
 fi
 

--- a/scripts/run_perf_test.sh
+++ b/scripts/run_perf_test.sh
@@ -11,7 +11,8 @@ DOCKER_COMPOSE_RUNNING=`docker compose ls --filter name=valkey-ldap -q && true`
 STOP_SERVERS=
 
 if [ -z $DOCKER_COMPOSE_RUNNING ]; then
-    ./scripts/start_valkey_ldap.sh
+    ./scripts/start_valkey_ldap.sh $*
+    shift
     STOP_SERVERS=true
 fi
 

--- a/scripts/run_test_cli.sh
+++ b/scripts/run_test_cli.sh
@@ -11,7 +11,7 @@ DOCKER_COMPOSE_RUNNING=`docker compose ls --filter name=valkey-ldap -q && true`
 STOP_SERVERS=""
 
 if [ -z $DOCKER_COMPOSE_RUNNING ]; then
-    ./scripts/start_valkey_ldap.sh
+    ./scripts/start_valkey_ldap.sh $*
     STOP_SERVERS=true
 fi
 

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -9,7 +9,7 @@ cargo build
 STOP_SERVERS=
 
 if [ -z $DOCKER_COMPOSE_RUNNING ]; then
-    ./scripts/start_valkey_ldap.sh
+    ./scripts/start_valkey_ldap.sh $*
     STOP_SERVERS=true
 fi
 

--- a/scripts/start_valkey_ldap.sh
+++ b/scripts/start_valkey_ldap.sh
@@ -4,6 +4,13 @@ while [[ ! $PWD/ = */valkey-ldap/ ]]; do
     cd ..
 done
 
+VALKEY_VERSION=
+if [ -z "$1" ]; then
+    VALKEY_VERSION=8.1
+else
+    VALKEY_VERSION=$1
+fi
+
 cargo build
 
 DOCKER_COMPOSE_RUNNING=`docker compose ls --filter name=valkey-ldap -q && true`
@@ -13,8 +20,8 @@ if [ ! -z $DOCKER_COMPOSE_RUNNING ]; then
 else
     pushd scripts/docker > /dev/null
 
-    docker compose up -d --wait
-    docker compose logs -f > /tmp/valkey-ldap.log 2>&1 &
+    docker compose --profile valkey-${VALKEY_VERSION} up -d --wait
+    docker compose --profile valkey-${VALKEY_VERSION} logs -f > /tmp/valkey-ldap.log 2>&1 &
 
     popd > /dev/null
 fi

--- a/scripts/stop_valkey_ldap.sh
+++ b/scripts/stop_valkey_ldap.sh
@@ -13,6 +13,9 @@ fi
 
 pushd scripts/docker > /dev/null
 
-docker compose down
+docker compose --profile valkey-7.2 down
+docker compose --profile valkey-8.0 down
+docker compose --profile valkey-8.1 down
+docker compose rm -f valkey-7.2 valkey-8.0 valkey-8.1
 
 popd > /dev/null

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,17 @@
 mod auth;
 mod commands;
 mod configs;
+mod logging;
 mod version;
 mod vkldap;
 
 use log::error;
 use valkey_module::{
-    Context, Status, ValkeyGILGuard, ValkeyString, configuration::ConfigurationFlags,
-    logging::standard_log_implementation, valkey_module,
+    Context, Status, ValkeyGILGuard, ValkeyString, configuration::ConfigurationFlags, valkey_module,
 };
 
 use auth::ldap_auth_blocking_callback;
+use logging::standard_log_implementation;
 use version::module_version;
 use vkldap::failure_detector;
 use vkldap::scheduler;
@@ -18,7 +19,7 @@ use vkldap::scheduler;
 fn initializer(ctx: &Context, _args: &[ValkeyString]) -> Status {
     ctx.log_debug("initializing LDAP module");
 
-    let res = standard_log_implementation::setup();
+    let res = standard_log_implementation::setup_for_context(ctx);
     if let Err(err) = res {
         ctx.log_warning(format!("failed to setup log: {err}").as_str());
     }
@@ -54,6 +55,7 @@ fn deinitializer(ctx: &Context) -> Status {
         error!("{err}");
         return Status::Err;
     }
+
     Status::Ok
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,154 @@
+use std::ffi::CString;
+use strum_macros::AsRefStr;
+use valkey_module::raw;
+
+const NOT_INITIALISED_MESSAGE: &str = "Valkey module hasn't been initialised.";
+
+/// [ValkeyLogLevel] is a level of logging which can be used when
+/// logging with Redis. See [raw::RedisModule_Log] and the official
+/// valkey [reference](https://valkey.io/topics/modules-api-ref/).
+#[derive(Clone, Copy, Debug, AsRefStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum ValkeyLogLevel {
+    Debug,
+    Notice,
+    Verbose,
+    Warning,
+}
+
+impl From<log::Level> for ValkeyLogLevel {
+    fn from(value: log::Level) -> Self {
+        match value {
+            log::Level::Error | log::Level::Warn => Self::Warning,
+            log::Level::Info => Self::Notice,
+            log::Level::Debug => Self::Verbose,
+            log::Level::Trace => Self::Debug,
+        }
+    }
+}
+
+pub(crate) fn log_internal<L: Into<ValkeyLogLevel>>(
+    ctx: *mut raw::RedisModuleCtx,
+    level: L,
+    message: &str,
+) {
+    if cfg!(test) {
+        return;
+    }
+
+    let level = CString::new(level.into().as_ref()).unwrap();
+    let fmt = CString::new(message).unwrap();
+    unsafe {
+        raw::RedisModule_Log.expect(NOT_INITIALISED_MESSAGE)(ctx, level.as_ptr(), fmt.as_ptr())
+    }
+}
+
+/// The [log] crate implementation of logging.
+pub mod standard_log_implementation {
+    use std::sync::{Mutex, OnceLock};
+
+    use super::*;
+    use log::{Metadata, Record, SetLoggerError};
+    use valkey_module::Context;
+
+    /// The struct which has an implementation of the [log] crate's
+    /// logging interface.
+    ///
+    /// # Note
+    ///
+    /// Valkey does not support logging at the [log::Level::Error] level,
+    /// so logging at this level will be converted to logging at the
+    /// [log::Level::Warn] level under the hood.
+    struct ValkeyGlobalLogger {
+        context: Mutex<*mut raw::RedisModuleCtx>,
+    }
+
+    impl ValkeyGlobalLogger {
+        fn new() -> Self {
+            Self {
+                context: Mutex::new(std::ptr::null_mut()),
+            }
+        }
+
+        fn init(&self, context: &Context) {
+            let mut ctx = self.context.lock().unwrap();
+            let detached_ctx =
+                unsafe { raw::RedisModule_GetDetachedThreadSafeContext.unwrap()(context.ctx) };
+            *ctx = detached_ctx;
+        }
+    }
+
+    // The pointer of the Global logger can only be changed once during
+    // the startup. Once one of the [std::sync::OnceLock] or
+    // [std::sync::OnceCell] is stabilised, we can remove these unsafe
+    // trait implementations in favour of using the aforementioned safe
+    // types.
+    unsafe impl Send for ValkeyGlobalLogger {}
+    unsafe impl Sync for ValkeyGlobalLogger {}
+
+    /// Sets this logger as a global logger. Use this method to set
+    /// up the logger. If this method is never called, the default
+    /// logger is used which redirects the logging to the standard
+    /// input/output streams.
+    ///
+    /// # Note
+    ///
+    /// The logging context is created from the module context passed in
+    /// `context`.
+    ///
+    /// In case this function is invoked before the initialisation, and
+    /// so without the valkey module context, no context will be used for
+    /// the logging, however, the logger will be set.
+    ///
+    /// # Example
+    ///
+    /// This function may be called on a module startup, within the
+    /// module initialisation function (specified in the
+    /// [crate::redis_module] as the `init` argument, which will be used
+    /// for the module initialisation and will be passed to the
+    /// [raw::Export_RedisModule_Init] function when loading the
+    /// module).
+    #[allow(dead_code)]
+    pub fn setup_for_context(context: &Context) -> Result<(), SetLoggerError> {
+        let logger = logger();
+        logger.init(context);
+        log::set_logger(logger).map(|()| log::set_max_level(log::LevelFilter::Trace))
+    }
+
+    fn logger() -> &'static ValkeyGlobalLogger {
+        static LOGGER: OnceLock<ValkeyGlobalLogger> = OnceLock::new();
+        LOGGER.get_or_init(|| ValkeyGlobalLogger::new())
+    }
+
+    impl log::Log for ValkeyGlobalLogger {
+        fn enabled(&self, _: &Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &Record) {
+            if !self.enabled(record.metadata()) {
+                return;
+            }
+
+            let message = match record.level() {
+                log::Level::Debug | log::Level::Trace => {
+                    format!(
+                        "'{}' {}:{}: {}",
+                        record.module_path().unwrap_or_default(),
+                        record.file().unwrap_or("Unknown"),
+                        record.line().unwrap_or(0),
+                        record.args()
+                    )
+                }
+                _ => record.args().to_string(),
+            };
+
+            let ctx = self.context.lock().unwrap();
+            log_internal(*ctx, record.level(), &message);
+        }
+
+        fn flush(&self) {
+            // The flushing isn't required for the Valkey logging.
+        }
+    }
+}


### PR DESCRIPTION
This commit makes changes to the integration testing infrastructure to enable running integration tests against the different supported valkey versions, namely 7.2, 8.0, and 8.1.

We also enable ASAN compilation of Valkey server, to detect memory errors.

When we enabled ASAN, we immediately found a memory error in the logging system, and we also fix the problem in this commit.