### PR TITLE
Improve `INFO` output by showing the hostname instead of server URL

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -21,7 +21,7 @@ fn add_ldap_status_section(ctx: &InfoContext, _for_crash_report: bool) -> Valkey
     for (idx, server) in servers_health.iter().enumerate() {
         let mut dict = builder
             .add_dictionary(format!("server_{}", idx).as_str())
-            .field("url", server.get_url_ref().as_str())?;
+            .field("host", server.get_host_string())?;
 
         match server.get_status() {
             VkLdapServerStatus::HEALTHY => {
@@ -30,7 +30,7 @@ fn add_ldap_status_section(ctx: &InfoContext, _for_crash_report: bool) -> Valkey
                 match server.get_ping_time() {
                     Some(time) => {
                         dict = dict.field(
-                            "ping_time(ms)",
+                            "ping_time_ms",
                             (time.as_micros() as f64 / 1000.0).to_string(),
                         )?;
                     }

--- a/src/vkldap/server.rs
+++ b/src/vkldap/server.rs
@@ -68,4 +68,11 @@ impl VkLdapServer {
     pub fn get_ping_time(&self) -> Option<Duration> {
         self.ping_time
     }
+
+    pub fn get_host_string(&self) -> String {
+        match self.url.host() {
+            Some(host) => host.to_string(),
+            None => self.url.to_string(),
+        }
+    }
 }

--- a/test/integration/test_ldap.py
+++ b/test/integration/test_ldap.py
@@ -150,8 +150,7 @@ class LdapModuleFailoverTest(LdapTestCase):
             status = parse_valkey_info_section(result.decode("utf-8"))
 
             for server in status.values():
-                url = urlparse(server["url"])
-                if url.hostname == server_name:
+                if server["host"] == server_name:
                     if server["status"] == status_desc:
                         return
 


### PR DESCRIPTION
This commit also renames the server ping time from `ping_time(ms)` to `ping_time_ms`.