### PR TITLE
Removed `ldap.auth_enabled` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ After creating the above user `bob` in Valkey, it will only be possible to authe
 
 | Config Name | Type | Default | Description |
 | ------------|------|---------|-------------|
-| `ldap.auth_enabled` | boolean | `yes` | Flag to control whether the module should process an authentication request or not. |
 | `ldap.auth_mode` | Enum(`bind`, `search+bind`) | `bind` | The authentication method. Check the [Authentication Modes](#ldap-authentication-modes) section for more information about the differences. |
 | `ldap.servers` | string | `""` | Comma separated list of LDAP URLs of the form `ldap[s]://<domain>:<port>`. |
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -86,7 +86,6 @@ lazy_static! {
     pub static ref LDAP_TLS_KEY_PATH: ValkeyGILGuard<ValkeyString> =
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
     pub static ref LDAP_USE_STARTTLS: ValkeyGILGuard<bool> = ValkeyGILGuard::default();
-    pub static ref LDAP_AUTH_ENABLED: ValkeyGILGuard<bool> = ValkeyGILGuard::default();
     pub static ref LDAP_AUTH_MODE: ValkeyGILGuard<LdapAuthMode> =
         ValkeyGILGuard::new(LdapAuthMode::Bind);
     pub static ref LDAP_SEARCH_BASE: ValkeyGILGuard<ValkeyString> =
@@ -275,8 +274,8 @@ pub fn is_starttls_enabled<T: ValkeyLockIndicator>(ctx: &T) -> bool {
 }
 
 pub fn is_auth_enabled<T: ValkeyLockIndicator>(ctx: &T) -> bool {
-    let auth_enabled = LDAP_AUTH_ENABLED.lock(ctx);
-    *auth_enabled
+    let servers = LDAP_SERVER_LIST.lock(ctx);
+    !servers.is_empty()
 }
 
 pub fn is_bind_mode<T: ValkeyLockIndicator>(ctx: &T) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,13 +205,6 @@ valkey_module! {
                 ConfigurationFlags::DEFAULT,
                 Some(Box::new(configs::on_connection_setting_change))
             ],
-            [
-                "auth_enabled",
-                &*configs::LDAP_AUTH_ENABLED,
-                true,
-                ConfigurationFlags::DEFAULT,
-                None
-            ],
         ],
         enum: [
             [

--- a/test/integration/test_ldap.py
+++ b/test/integration/test_ldap.py
@@ -82,7 +82,7 @@ class LdapModuleBindTest(LdapTestCase):
         self.assertTrue(resp.decode() == "user1")
 
     def test_ldap_disabled(self):
-        self.vk.execute_command("CONFIG", "SET", "ldap.auth_enabled", "no")
+        self.vk.execute_command("CONFIG", "SET", "ldap.servers", "")
         self.vk.execute_command("AUTH", "user1", "pass")
         resp = self.vk.execute_command("ACL", "WHOAMI")
         self.assertTrue(resp.decode() == "user1")

--- a/test/integration/util.py
+++ b/test/integration/util.py
@@ -36,8 +36,6 @@ class LdapTestCase(TestCase):
     def setUp(self):
         vk = valkey.Valkey(host="localhost", port=6379, db=0)
 
-        vk.execute_command("CONFIG", "SET", "ldap.auth_enabled", "yes")
-
         # LDAP server location
         vk.execute_command("CONFIG", "SET", "ldap.servers", "ldap://ldap ldap://ldap-2")
 


### PR DESCRIPTION
This commit removes the `ldap.auth_enabled` configuration option since it's redudant with setting `ldap.servers` to an empty string.

From now on, while the `ldap.servers` does not have any server configured, the LDAP module will skip any authentication requests.