### PR TITLE
Make valkey an RPM weak dependency of valkey-ldap module

### DIFF
--- a/packaging/valkey-ldap.spec.in
+++ b/packaging/valkey-ldap.spec.in
@@ -25,7 +25,7 @@ BuildRequires:  openldap-devel
 BuildRequires:  clang-devel
 BuildRequires:  wget
 
-Requires:       valkey >= 8.0
+Recommends:     valkey >= 7.2
 
 %global _description %{expand:
 An LDAP authentication module for Valkey.}


### PR DESCRIPTION
This commit changes the type dependency between the valkey-ldap module and the valkey server in the RPM spec file to be a weak dependency.

We're making valkey server to be a weak dependecy because sometimes users might install valkey server without using the OS package manager, and we still want the user to be allowed to install valkey-ldap module using the OS package manager even if valkey is not detected as installed.