### PR TITLE
[backport] Add valkey and ldap services logs to pytest report on test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
     paths:
       - 'src/**'
-      - 'test/unit'
-      - 'test/integration'
+      - 'test/unit/**'
+      - 'test/integration/**'
 
 jobs:
   tests:

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.hookimpl(wrapper=True, tryfirst=True)
+def pytest_runtest_makereport(item, call):
+    # execute all other hooks to obtain the report object
+    rep = yield
+
+    # we only look at actual failing test calls, not setup/teardown
+    if rep.when == "call" and rep.failed:
+        with open("/tmp/valkey-ldap.log", "r") as log_file:
+            logs = log_file.read()
+        rep.sections.append(("Valkey and LDAP Services Logs", logs))
+
+    return rep


### PR DESCRIPTION
This commit adds the Valkey and LDAP service container logs that are run with integration tests, to the pytest report when some pytest fails.

This way we can more easily identify the root cause of the failure.

Backport of: #41