### PR TITLE
Update release process to match version tags format

### DIFF
--- a/.github/workflows/release_packaging.yml
+++ b/.github/workflows/release_packaging.yml
@@ -3,7 +3,7 @@ name: Release Packaging
 on:
   push:
     tags:
-        - 'v*'
+        - '*.*.*'
 
 jobs:
   Create_RPM_Package:
@@ -39,41 +39,8 @@ jobs:
           run: |
             ./packaging/build_srpm.sh
 
-        - name: Trigger Copr Build
+        - name: Trigger and wait for Copr Build
           run : |
             SRPM=`ls valkey-ldap*.rpm`
             copr-cli --config copr.config build valkey-ldap $SRPM
 
-  Create_GitHub_Release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build
-        run: cargo build --release
-
-      - name: Extract version from tag
-        id: extract_version
-        run: |
-          VERSION="${GITHUB_REF##*/}"
-          VERSION="${VERSION#v}"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Extract changelog for this version
-        id: changelog
-        run: |
-          CHANGELOG=$(./scripts/extract_changelog.sh "${{ steps.extract_version.outputs.VERSION }}")
-          echo "log<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: ${{ steps.extract_version.outputs.VERSION }}
-          body: ${{ steps.changelog.outputs.log }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/HOWTORELEASE.md
+++ b/HOWTORELEASE.md
@@ -14,20 +14,20 @@ These are the steps to make a release candidate for version `X.X.0`:
    - Update the links at the bottom of the file:
 
 ```
-[unreleased]: https://github.com/valkey-io/valkey-ldap/compare/vX.X.0-rc1...HEAD
-[X.X.0]: https://github.com/valkey-io/valkey-ldap/releases/tag/vX.X.0-rc1
+[unreleased]: https://github.com/valkey-io/valkey-ldap/compare/X.X.0-rc1...HEAD
+[X.X.0_rc1]: https://github.com/valkey-io/valkey-ldap/releases/tag/X.X.0-rc1
 ```
 
 6. Run `cargo test --features enable-system-alloc` to check that versions match and to update `Cargo.lock` file.
-7. Create a commit with title `Bump to vX.X.0-rc1` containing the modifications made in the previous steps.
+7. Create a commit with title `Bump to X.X.0-rc1` containing the modifications made in the previous steps.
 8. Create a branch with name `X.X` and switch to that branch.
-8. Create an annotated tag for the above commit: `git tag -s -a vX.X.0-rc1 -m"version X.X.0-rc1"`.
+8. Create an annotated tag for the above commit: `git tag -s -a X.X.0-rc1 -m"version X.X.0-rc1"`.
 9. Push commit and tag to github repo: `git push <remote> X.X --tags`
-   - This will trigger a GitHub action that will create a draft release for version `X.X.0-rc1` and trigger the RPMs build in Copr.
+   - This will trigger a GitHub action that triggers the RPMs build in Copr.
 10. Switch back to the main branch.
 11. Update version string in `Cargo.toml` from `version = "X.X.0-rc1"` to `version = "Y.Y.0-dev"` where `Y.Y.0 > X.X.0`.
 12. Update version hex number in the unit test of `src/versions.rs`.
-13. Create a commit with title `Begin of vY.Y.0 development` containing the modifications made in the previous two steps and push it to the remote main branch.
+13. Create a commit with title `Begin of Y.Y.0 development` containing the modifications made in the previous two steps and push it to the remote main branch.
 14. Review the GitHub release draft and publish the release when ready.
 
 
@@ -45,13 +45,13 @@ Assuming that version `X.X.0-rc1` has been cut of the main branch. To create the
    - Update the links at the bottom of the file:
 
 ```
-[unreleased]: https://github.com/valkey-io/valkey-ldap/compare/vX.X.0...HEAD
-[X.X.0]: https://github.com/valkey-io/valkey-ldap/releases/tag/vX.X.0
-[X.X.0_rc1]: https://github.com/valkey-io/valkey-ldap/releases/tag/vX.X.0-rc1
+[unreleased]: https://github.com/valkey-io/valkey-ldap/compare/X.X.0...HEAD
+[X.X.0]: https://github.com/valkey-io/valkey-ldap/releases/tag/X.X.0
+[X.X.0_rc1]: https://github.com/valkey-io/valkey-ldap/releases/tag/X.X.0-rc1
 ```
 
-5. Create a commit with title `Bump to vX.X.0` containing the modifications made in the previous steps.
-6. Create an annotated tag for the above commit: `git tag -s -a vX.X.0 -m"version X.X.0"`.
+5. Create a commit with title `Bump to X.X.0` containing the modifications made in the previous steps.
+6. Create an annotated tag for the above commit: `git tag -s -a X.X.0 -m"version X.X.0"`.
 7. Push commit and tag to github repo: `git push <remote> X.X --tags`
    - This will trigger a GitHub action that will create a draft release for version `X.X.0` and trigger the RPMs build in Copr.
 


### PR DESCRIPTION
In this commit we update the release process docs to match version tag format used by other valkey-io projects, which do not include the `v` prefix.

We also fix the release github action.