### PR TITLE
[backport] Fix shutdown of tokio runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Fixed module unload that was causing spurious illegal memory accesses
+
 ## [1.0.0-rc1] - 2025-06-12
 
 ### Added


### PR DESCRIPTION
This commit fixes the shutdown of the tokio runtime when the module is unloaded. Before this commit, the tokio runtime was not being shut down, and pending async tasks were still running, which would cause illegal memory accesses when logging messages because the logging system was using a no longer valid Valkey context structure.

This should fix the flaky test errors.

Backport of: #47