### PR TITLE
LDAP trigger for Valkey Extension Automation

### DIFF
--- a/.github/workflows/trigger_ldap_release.yml
+++ b/.github/workflows/trigger_ldap_release.yml
@@ -1,0 +1,35 @@
+name: Trigger Extension Update - LDAP
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version of Valkey LDAP module that was released
+        required: true
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version
+        id: determine-vars
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "Triggered by a release event."
+            VERSION=${{ github.event.release.tag_name }}
+          else
+            echo "Triggered by workflow dispatch."
+            VERSION=${{ inputs.version }}
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+      - name: Trigger extension update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EXTENSION_PAT }}
+          repository: ${{ github.repository_owner }}/valkey-extensions
+          event-type: ldap-release
+          client-payload: >
+            {
+              "version": "${{ steps.determine-vars.outputs.version }}",
+              "module": "ldap"
+            }


### PR DESCRIPTION
We want to automate the valkey-extensions repository so we don't have to manually update it. Tasks like version updates and Dockerfile modifications in the valkey-extensions repository are handled manually, leading to potential inconsistencies. The goal is to automate these processes through a pipeline that can handle version management, dynamic Dockerfile generation, and streamlined build workflows.

This pull request is a trigger which will activate when a new version of Valkey-Bloom has been released (RC or GA). Once activated, it will send the version over to a workflow in the valkey-extensions repository which will then carry out all the processes listed above.