### PR TITLE
We renamed Valkey-Extensions to Valkey-Bundle

### DIFF
--- a/.github/workflows/trigger_ldap_release.yml
+++ b/.github/workflows/trigger_ldap_release.yml
@@ -31,5 +31,5 @@ jobs:
           client-payload: >
             {
               "version": "${{ steps.determine-vars.outputs.version }}",
-              "module": "ldap"
+              "component": "ldap"
             }

--- a/.github/workflows/trigger_ldap_release.yml
+++ b/.github/workflows/trigger_ldap_release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.EXTENSION_PAT }}
-          repository: ${{ github.repository_owner }}/valkey-extensions
+          repository: ${{ github.repository_owner }}/valkey-bundle
           event-type: ldap-release
           client-payload: >
             {


### PR DESCRIPTION
We made the decision to rename all variables in the extensions repository to distinguish Valkey from the modules. Thus we need to rename the variables in this trigger as well.