### PR TITLE
Fix CONFIG REWRITE from always re-writing the `ldap.search_bind_passwd` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed bug in CONFIG REWRITE that would always re-write the `ldap.search_bind_passwd`
+  config with an obfuscated value
+
 ## Changed
 
 - Fixed module unload that was causing spurious illegal memory accesses

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -98,7 +98,7 @@ lazy_static! {
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
     pub static ref LDAP_SEARCH_BIND_DN: ValkeyGILGuard<ValkeyString> =
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
-    pub static ref LDAP_SEARCH_BIND_SHADOW_PASSWD: ValkeyGILGuard<ValkeyString> =
+    pub static ref LDAP_SEARCH_BIND_PASSWD: ValkeyGILGuard<ValkeyString> =
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
     pub static ref LDAP_SEARCH_DN_ATTRIBUTE: ValkeyGILGuard<ValkeyString> =
         ValkeyGILGuard::new(ValkeyString::create(None, ""));
@@ -106,11 +106,6 @@ lazy_static! {
     pub static ref LDAP_FAILURE_DETECTOR_INTERVAL: ValkeyGILGuard<i64> = ValkeyGILGuard::new(1);
     pub static ref LDAP_TIMEOUT_CONNECTION: ValkeyGILGuard<i64> = ValkeyGILGuard::new(10);
     pub static ref LDAP_TIMEOUT_LDAP_OPERATION: ValkeyGILGuard<i64> = ValkeyGILGuard::new(10);
-}
-
-lazy_static! {
-    static ref LDAP_SEARCH_BIND_PASSWD: ValkeyGILGuard<ValkeyString> =
-        ValkeyGILGuard::new(ValkeyString::create(None, ""));
 }
 
 pub fn refresh_ldap_settings_cache<T: ValkeyLockIndicator>(ctx: &T) {
@@ -184,18 +179,6 @@ pub fn process_server_list(server_list: String) -> Result<(), ValkeyError> {
     }
 
     Ok(())
-}
-
-pub fn on_password_config_set<G, T: ConfigurationValue<ValkeyString>>(
-    ctx: &ConfigurationContext,
-    _name: &str,
-    val: &'static T,
-) -> Result<(), ValkeyError> {
-    LDAP_SEARCH_BIND_PASSWD.set(ctx, val.get(ctx))?;
-
-    refresh_ldap_settings_cache(ctx);
-
-    val.set(ctx, ValkeyString::create(None, "*********"))
 }
 
 pub fn on_ldap_setting_change<G, T: ConfigurationValue<G>>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod vkldap;
 
 use log::error;
 use valkey_module::{
-    Context, Status, ValkeyGILGuard, ValkeyString, configuration::ConfigurationFlags, valkey_module,
+    Context, Status, ValkeyString, configuration::ConfigurationFlags, valkey_module,
 };
 
 use auth::ldap_auth_blocking_callback;
@@ -183,11 +183,10 @@ valkey_module! {
             ],
             [
                 "search_bind_passwd",
-                &*configs::LDAP_SEARCH_BIND_SHADOW_PASSWD,
+                &*configs::LDAP_SEARCH_BIND_PASSWD,
                 "",
-                ConfigurationFlags::SENSITIVE,
-                None,
-                Some(Box::new(configs::on_password_config_set::<ValkeyString, ValkeyGILGuard<ValkeyString>>))
+                ConfigurationFlags::SENSITIVE | ConfigurationFlags::HIDDEN,
+                Some(Box::new(configs::on_ldap_setting_change))
             ],
             [
                 "search_dn_attribute",

--- a/test/integration/test_ldap.py
+++ b/test/integration/test_ldap.py
@@ -124,7 +124,11 @@ class LdapModuleBindAndSearchTest(LdapTestCase):
 
     def test_ldap_bind_password_hidden(self):
         res = self.vk.execute_command("CONFIG", "GET", "ldap.search_bind_passwd")
-        self.assertEqual(res[1].decode("utf-8"), "*********")
+        self.assertEqual(res[1].decode("utf-8"), "admin123!")
+
+        res = self.vk.execute_command("CONFIG", "GET", "ldap.*")
+        for i in range(0, len(res), 2):
+            self.assertNotEqual(res[i].decode("utf-8"), "ldap.search_bind_passwd")
 
 
 class LdapModuleFailoverTest(LdapTestCase):


### PR DESCRIPTION
The current behavior of `CONFIG REWRITE` is that it will always write an obfuscated value for the `ldap.search_bind_passwd` config in valkey.conf even if `ldap.search_bind_passwd` has not been updated.

This behavior is due to a strategy of making sure that the value of `ldap.search_bind_passwd`, loaded from valkey.conf when the server starts, does not show up in `CONFIG GET` operations. To achieve this, the module implementation overrides the update procedure of the `ldap.search_bind_passwd`, and stores the password in a temporary variable and writes `******` in the `ldap.search_bind_passwd` config variable.

The side-effect of this implementation is that `CONFIG REWRITE` thinks that the config has changed and writes the current obfuscated value `******`.

This commit fixes the problem by abandoning the strategy of obfuscating the config value, and adds teh `HIDDEN` flag to the config variable declaration to prevent `CONFIG GET ldap.*` command from showing the password value.

Fixes: #52 