### PR TITLE
Fix rust compiler version in CI github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Change rust toolchain to 1.87.0
+        run: rustup override set 1.87.0
+
       - name: Check if only the relevant files for testing the module are changed
         id: filter
         run: |

--- a/packaging/valkey-ldap.spec.in
+++ b/packaging/valkey-ldap.spec.in
@@ -43,7 +43,7 @@ An LDAP authentication module for Valkey.}
 # Install rust compiler
 wget https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
 chmod +x rustup-init
-./rustup-init -y
+./rustup-init --default-toolchain 1.87.0 -y
 
 
 set -euo pipefail


### PR DESCRIPTION
For some unknown reason, since rust 1.88.0 version, the module is crashing with a segfault inside tokio runtime code, as soon as we connect to an LDAP server.

Here's the crash error we get:

```
thread 'tokio-runtime-worker' panicked at /home/rdias/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.0/src/runtime/io/driver.rs:177:49:
misaligned pointer dereference: address must be a multiple of 0x80 but is 0x511000010240
```

To avoid this problem, we're setting the rust compiler version in our CI infrastructure to 1.87.0.