### PR TITLE
fix connectionpool reconstruct

### DIFF
--- a/scripts/docker/Dockerfile-ldap
+++ b/scripts/docker/Dockerfile-ldap
@@ -1,0 +1,11 @@
+FROM osixia/openldap:1.5.0
+
+RUN sed -i \
+    -e 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' \
+    -e 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+    -e '/buster-updates/d' \
+    -e '/buster-backports/d' \
+    /etc/apt/sources.list \
+    && apt-get update -qq \
+    && apt-get install -y -qq iptables \
+    && rm -rf /var/lib/apt/lists/*

--- a/scripts/docker/docker-compose.yaml
+++ b/scripts/docker/docker-compose.yaml
@@ -1,9 +1,14 @@
 name: valkey-ldap
 services:
   ldap:
-    image: osixia/openldap:1.5.0
+    build:
+      dockerfile: Dockerfile-ldap
+      context: ./
+    image: valkey-ldap-openldap
     profiles: ["valkey-7.2", "valkey-8.0", "valkey-8.1"]
     container_name: ldap
+    cap_add:
+        - NET_ADMIN
     environment:
         - LDAP_ORGANISATION=valkey
         - LDAP_DOMAIN=valkey.io
@@ -19,7 +24,7 @@ services:
         - ./certs:/container/service/slapd/assets/certs
 
   ldap-2:
-    image: osixia/openldap:1.5.0
+    image: valkey-ldap-openldap
     profiles: ["valkey-7.2", "valkey-8.0", "valkey-8.1"]
     container_name: ldap-2
     environment:

--- a/scripts/populate_ldap.sh
+++ b/scripts/populate_ldap.sh
@@ -8,5 +8,5 @@ done
 ADMIN_PASSWD=admin123!
 ADMIN_DN="cn=admin,dc=valkey,dc=io"
 
-ldapadd -x -w ${ADMIN_PASSWD} -D ${ADMIN_DN} < test/ldap_users.txt
-ldapadd -H ldap://localhost:390 -x -w ${ADMIN_PASSWD} -D ${ADMIN_DN} < test/ldap_users.txt
+docker exec -i ldap ldapadd -x -w ${ADMIN_PASSWD} -D ${ADMIN_DN} < test/ldap_users.txt
+docker exec -i ldap-2 ldapadd -x -w ${ADMIN_PASSWD} -D ${ADMIN_DN} < test/ldap_users.txt

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -6,13 +6,15 @@ done
 
 cargo build || exit 1
 
+VALKEY_VERSION=${1:-8.1}
+shift
+
 DOCKER_COMPOSE_RUNNING=`docker compose ls --filter name=valkey-ldap -q && true`
 
 STOP_SERVERS=
 
 if [ -z $DOCKER_COMPOSE_RUNNING ]; then
-    ./scripts/start_valkey_ldap.sh $*
-    shift
+    ./scripts/start_valkey_ldap.sh $VALKEY_VERSION
     STOP_SERVERS=true
 fi
 

--- a/src/vkldap/connection.rs
+++ b/src/vkldap/connection.rs
@@ -52,8 +52,13 @@ impl ConnectionQueue {
             match VkLdapConnection::new(&settings, server).await {
                 Ok(conn) => self.queue.push_front(conn),
                 Err(err) => {
-                    self.close_connections().await;
-                    return Err(err);
+                    if self.queue.is_empty() {
+                        return Err(err);
+                    }
+                    // Partial success: keep what connected and shrink the pool
+                    // to match. A later refresh will try to grow it back to full size.
+                    self.size = self.queue.len();
+                    break;
                 }
             }
         }

--- a/src/vkldap/context.rs
+++ b/src/vkldap/context.rs
@@ -88,11 +88,13 @@ impl VkLdapContext {
             return ();
         }
 
-        let server = &mut self.servers[server.get_id()];
-        if server.get_url_ref() != server.get_url_ref() {
+        // Guard: the slot may have been replaced by a different server since
+        // the caller took a snapshot (e.g. after ldap.servers was reconfigured).
+        if self.servers[server.get_id()].get_url_ref() != server.get_url_ref() {
             return ();
         }
 
+        let server = &mut self.servers[server.get_id()];
         if server.get_status() != status {
             let pre_status = server.get_status();
             let url = server.get_url_ref();

--- a/src/vkldap/context.rs
+++ b/src/vkldap/context.rs
@@ -112,13 +112,18 @@ impl VkLdapContext {
             return Err(VkLdapError::NoServerConfigured);
         }
 
+        let mut unhealthy = Vec::new();
         for server in self.servers.iter() {
             if server.is_healthy() {
                 return Ok(server.clone());
             }
+            unhealthy.push((
+                server.get_url_ref().to_string(),
+                server.get_status().to_string(),
+            ));
         }
 
-        Err(VkLdapError::NoHealthyServerAvailable)
+        Err(VkLdapError::NoHealthyServerAvailable(unhealthy))
     }
 }
 

--- a/src/vkldap/errors.rs
+++ b/src/vkldap/errors.rs
@@ -14,7 +14,7 @@ pub enum VkLdapError {
     MultipleEntryFound(String),
     InvalidDNAttribute(String),
     NoServerConfigured,
-    NoHealthyServerAvailable,
+    NoHealthyServerAvailable(Vec<(String, String)>),
     FailedToStopFailuredDetectorThread,
     FailedToShutdownJobScheduler,
     FailedToSendJobToScheduler(String),
@@ -79,10 +79,13 @@ impl std::fmt::Display for VkLdapError {
                 f,
                 "no server set in configuration. Please set ldap.servers config option"
             ),
-            VkLdapError::NoHealthyServerAvailable => write!(
-                f,
-                "all servers set in configuration are unhealthy. Please check the logs for more information"
-            ),
+            VkLdapError::NoHealthyServerAvailable(servers) => {
+                let detail: Vec<String> = servers
+                    .iter()
+                    .map(|(url, reason)| format!("{url} ({reason})"))
+                    .collect();
+                write!(f, "all servers are unhealthy: {}", detail.join(", "))
+            }
             VkLdapError::FailedToStopFailuredDetectorThread => write!(
                 f,
                 "failed to wait for the failure detector thread to finish"

--- a/src/vkldap/failure_detector.rs
+++ b/src/vkldap/failure_detector.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use futures::future;
-use log::{debug, error};
+use log::{debug, error, warn};
 
 use super::context;
 use super::errors::VkLdapError;
@@ -21,16 +21,18 @@ async fn check_server_health(server: VkLdapServer) {
         let res = pool_conn.conn.ping().await;
         let ping_time = now.elapsed();
 
-        context::return_pool_connection(pool_conn).await;
-
         if let Err(err) = res {
+            // Mark unhealthy before returning the connection so that no request
+            // can dequeue the dead connection between the two operations.
             context::update_server_status(
                 &server,
                 VkLdapServerStatus::UNHEALTHY(err.to_string()),
                 None,
             )
             .await;
+            context::return_pool_connection(pool_conn).await;
         } else {
+            context::return_pool_connection(pool_conn).await;
             context::update_server_status(
                 &server,
                 super::server::VkLdapServerStatus::HEALTHY,
@@ -44,8 +46,9 @@ async fn check_server_health(server: VkLdapServer) {
         match conn_res {
             Ok(mut conn) => {
                 let res = conn.ping().await;
-                if let Ok(_) = res {
-                    context::refresh_pool_connections(&server).await;
+                match res {
+                    Ok(_) => context::refresh_pool_connections(&server).await,
+                    Err(err) => warn!("recovery ping failed for {}: {err}", server.get_url_ref()),
                 }
             }
             Err(err) => {

--- a/test/integration/test_ldap.py
+++ b/test/integration/test_ldap.py
@@ -203,15 +203,168 @@ class LdapModuleFailoverTest(LdapTestCase):
         time.sleep(1)
 
         service = DOCKER_SERVICES.stop_service("ldap")
+        try:
+            self._wait_for_ldap_server_status("ldap", "unhealthy")
+            time.sleep(1)
+
+            stop_worker = True
+            worker_thread.join()
+            self.assertIsNone(worker_result["error"])
+        finally:
+            if service is not None:
+                DOCKER_SERVICES.restart_service(service)
+                self._wait_for_ldap_server_status("ldap", "healthy")
+
+        self.test_ldap_auth()
+
+    def test_hard_drop_no_recovery(self):
+        self.vk.execute_command("CONFIG", "SET", "ldap.connection_pool_size", "5")
+        # Kill both servers hard
+        service = DOCKER_SERVICES.stop_service("ldap")
+        service2 = DOCKER_SERVICES.stop_service("ldap-2")
         self._wait_for_ldap_server_status("ldap", "unhealthy")
-        time.sleep(1)
+        # Restart immediately - server comes up slowly
         DOCKER_SERVICES.restart_service(service)
+        # Don't wait for healthy - fire auth attempts right away to stress pool reconstruction
+        time.sleep(1)
+        self._wait_for_ldap_server_status("ldap", "healthy")  # assert this eventually passes
+        self.test_ldap_auth()
+        DOCKER_SERVICES.restart_service(service2)
+        self._wait_for_ldap_server_status("ldap-2", "healthy")
+
+
+class LdapPoolReconstructionTest(LdapTestCase):
+    """
+    Reproduces the all-or-nothing reset_connections bug:
+    when the LDAP server is degraded enough to accept the FD probe connection
+    but rejects subsequent pool connections, the pool is left empty and the
+    server never transitions back to HEALTHY.
+
+    Uses iptables inside the ldap container (requires NET_ADMIN cap) to
+    rate-limit new TCP SYN packets (--syn) on port 389. The FD probe's SYN
+    consumes one burst slot; pool construction SYNs consume the rest or are
+    rejected. Established connections are unaffected so the LDAP protocol
+    can complete normally on allowed connections.
+    """
+
+    _IPTABLES_DROP_RULE = "iptables -I INPUT -p tcp --syn --dport 389 -j REJECT"
+
+    def setUp(self):
+        super().setUp()
+        DOCKER_SERVICES.assert_all_services_running()
+        self.vk.execute_command("CONFIG", "SET", "ldap.auth_mode", "bind")
+        self.vk.execute_command(
+            "CONFIG", "SET", "ldap.bind_dn_suffix", ",OU=devops,DC=valkey,DC=io"
+        )
+        self.vk.execute_command("CONFIG", "SET", "ldap.servers", "ldap://ldap")
+        self.vk.execute_command("CONFIG", "SET", "ldap.connection_pool_size", "5")
+        self._iptables_active = False
+        self._iptables_burst = 1
+
+    def tearDown(self):
+        if self._iptables_active:
+            self._remove_connection_limit()
+        self.vk.execute_command("CONFIG", "SET", "ldap.servers", "ldap://ldap ldap://ldap-2")
+        super().tearDown()
+
+    def _wait_for_ldap_server_status(self, server_name, status_desc):
+        while True:
+            result = self.vk.execute_command("INFO LDAP")
+            status = parse_valkey_info_section(result.decode("utf-8"))
+            for server in status.values():
+                if server["host"] == server_name:
+                    if server["status"] == status_desc:
+                        return
+            time.sleep(2)
+
+    def _rate_rule(self, burst):
+        return (
+            f"iptables -I INPUT -p tcp --syn --dport 389 "
+            f"-m limit --limit 1/sec --limit-burst {burst} -j ACCEPT"
+        )
+
+    def _apply_connection_limit(self, burst=1):
+        self._iptables_burst = burst
+        # Insert REJECT first so it lands at position 1, then insert ACCEPT
+        # which pushes REJECT to position 2. Final chain: [ACCEPT(rate), REJECT].
+        DOCKER_SERVICES.exec_in("ldap", self._IPTABLES_DROP_RULE)
+        DOCKER_SERVICES.exec_in("ldap", self._rate_rule(burst))
+        self._iptables_active = True
+
+    def _remove_connection_limit(self):
+        DOCKER_SERVICES.exec_in("ldap", self._rate_rule(self._iptables_burst).replace("-I", "-D"))
+        DOCKER_SERVICES.exec_in("ldap", self._IPTABLES_DROP_RULE.replace("-I", "-D"))
+        self._iptables_active = False
+
+    def _get_ldap_server_status(self):
+        result = self.vk.execute_command("INFO LDAP")
+        status = parse_valkey_info_section(result.decode("utf-8"))
+        for server in status.values():
+            if server.get("host") == "ldap":
+                return server.get("status")
+        return None
+
+    def test_pool_reconstruction_failure_blocks_recovery(self):
+        code, _ = DOCKER_SERVICES.exec_in("ldap", "which iptables")
+        if code != 0:
+            self.skipTest("iptables not available in ldap container")
+
+        self.vk.execute_command("AUTH", "user1", "user1@123")
+
+        service = DOCKER_SERVICES.stop_service("ldap")
+        self._wait_for_ldap_server_status("ldap", "unhealthy")
+
+        DOCKER_SERVICES.restart_service(service)
+
+        # Apply the limit before the port is open so no FD tick can slip
+        # through before the iptables rules are in place.
+        # Allow only 1 new TCP SYN (burst=1) on port 389.
+        # The FD probe's SYN uses the sole burst slot; every pool
+        # construction SYN is rejected, leaving the pool empty.
+        self._apply_connection_limit()
+
+        DOCKER_SERVICES.wait_for_port("ldap", 389)
+
+        # Give the FD several ticks to attempt recovery (interval=1s)
+        time.sleep(6)
+
+        self.assertEqual(
+            self._get_ldap_server_status(), "unhealthy",
+            "server should remain UNHEALTHY when all pool connections fail (0 connections rebuilt)",
+        )
+
+        # Remove the limit — ldap is now fully accessible
+        self._remove_connection_limit()
+
+        # The next successful FD tick should complete pool construction and recover
         self._wait_for_ldap_server_status("ldap", "healthy")
+        self.vk.execute_command("AUTH", "user1", "user1@123")
 
-        stop_worker = True
-        worker_thread.join()
+    def test_partial_pool_reconstruction_recovers(self):
+        # burst=2: the FD probe uses slot 1, one pool connection uses slot 2,
+        # then connections 3-5 are rejected. reset_connections should accept the
+        # partial pool (1 connection) and mark the server HEALTHY rather than
+        # discarding everything and staying UNHEALTHY.
+        code, _ = DOCKER_SERVICES.exec_in("ldap", "which iptables")
+        if code != 0:
+            self.skipTest("iptables not available in ldap container")
 
-        self.assertIsNone(worker_result["error"])
+        self.vk.execute_command("AUTH", "user1", "user1@123")
+
+        service = DOCKER_SERVICES.stop_service("ldap")
+        self._wait_for_ldap_server_status("ldap", "unhealthy")
+
+        DOCKER_SERVICES.restart_service(service)
+        DOCKER_SERVICES.wait_for_port("ldap", 389)
+
+        self._apply_connection_limit(burst=2)
+
+        # With the partial-pool fix the server should recover even though only
+        # 1 of the 5 pool connections could be established.
+        self._wait_for_ldap_server_status("ldap", "healthy")
+        self.vk.execute_command("AUTH", "user1", "user1@123")
+
+        self._remove_connection_limit()
 
 
 class LdapModuleSearchAndBindFailoverTest(LdapModuleFailoverTest):

--- a/test/integration/test_ldap.py
+++ b/test/integration/test_ldap.py
@@ -186,6 +186,34 @@ class LdapModuleFailoverTest(LdapTestCase):
         DOCKER_SERVICES.restart_service(service2)
         self._wait_for_ldap_server_status("ldap-2", "healthy")
 
+    def test_unhealthy_error_includes_server_details(self):
+        service = DOCKER_SERVICES.stop_service("ldap")
+        service2 = DOCKER_SERVICES.stop_service("ldap-2")
+        self._wait_for_ldap_server_status("ldap", "unhealthy")
+        self._wait_for_ldap_server_status("ldap-2", "unhealthy")
+
+        with self.assertRaises(AuthenticationError):
+            self.vk.execute_command("AUTH", "user1", "user1@123")
+
+        # Valkey always returns a generic auth error to the client. The per-server
+        # error detail is exposed via INFO LDAP so operators can diagnose without
+        # digging through server logs.
+        info = parse_valkey_info_section(
+            self.vk.execute_command("INFO LDAP").decode("utf-8")
+        )
+        for server in info.values():
+            if server.get("host") in ("ldap", "ldap-2"):
+                self.assertEqual(server.get("status"), "unhealthy")
+                self.assertTrue(
+                    server.get("error", ""),
+                    f"server {server['host']} should expose a non-empty error reason",
+                )
+
+        DOCKER_SERVICES.restart_service(service)
+        DOCKER_SERVICES.restart_service(service2)
+        self._wait_for_ldap_server_status("ldap", "healthy")
+        self._wait_for_ldap_server_status("ldap-2", "healthy")
+
     def test_multi_auth_with_failover(self):
         stop_worker = False
         worker_result = {"success": True, "error": None}

--- a/test/integration/util.py
+++ b/test/integration/util.py
@@ -1,3 +1,4 @@
+import time
 from unittest import TestCase
 import docker
 import valkey
@@ -27,6 +28,20 @@ class DockerServices:
 
     def restart_service(self, serv):
         serv.restart()
+
+    def exec_in(self, name: str, cmd: str):
+        ct = self._find_container(name)
+        if ct is None:
+            raise RuntimeError(f"Container '{name}' not found")
+        result = ct.exec_run(["bash", "-c", cmd], user="root")
+        return result.exit_code, result.output
+
+    def wait_for_port(self, name: str, port: int):
+        while True:
+            code, _ = self.exec_in(name, f"bash -c 'echo > /dev/tcp/localhost/{port}' 2>/dev/null")
+            if code == 0:
+                return
+            time.sleep(0.5)
 
 
 DOCKER_SERVICES = DockerServices()


### PR DESCRIPTION
Fix for issue #58 and #59

- Fix guard in `update_server_status `that always evaluated to false, allowing stale server snapshots to corrupt status updates after a reconfiguration
- Fix silent failure in the unhealthy recovery branch of the failure detector : failed recovery pings now log a warning, either "server still down" or"server up but pool reconstruction failing"
- Fix dead connection returned to pool before ping result is checked, creating a window where another request could dequeue a failed connection
- Fix all-or-nothing pool reconstruction that discarded partially-reconstructed pools on error, leaving the server permanently unhealthy; partial pools are now retained and grown back on the next failure detector tick
- Improve `NoHealthyServerAvailable `error to include per-server status detail for easier diagnosis