### PR TITLE
NUL byte in logging fix

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -37,7 +37,10 @@ pub(crate) fn log_internal<L: Into<ValkeyLogLevel>>(
     }
 
     let level = CString::new(level.into().as_ref()).unwrap();
-    let fmt = CString::new(message).unwrap();
+    // Strip NUL bytes so attacker-controlled input (e.g. usernames) cannot
+    // cause CString::new to panic and crash the server.
+    let sanitized: String = message.chars().filter(|&c| c != '\0').collect();
+    let fmt = CString::new(sanitized).unwrap();
     unsafe {
         raw::RedisModule_Log.expect(NOT_INITIALISED_MESSAGE)(ctx, level.as_ptr(), fmt.as_ptr())
     }


### PR DESCRIPTION
A vulnerability in `logging.rs` panics on any NUL byte in message. Usernames are added into log strings (e.g. "failed to authenticate LDAP user {username}"), so attackers can send user\x001 as the username to crash the server.

The fix in `log_internal`: strips `NUL `bytes from the message before building the `CString`. 