### PR TITLE
Return actual error on failed AUTH attempt

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -26,7 +26,11 @@ fn auth_reply_callback(
             Err(err) => {
                 debug!("failed to authenticate LDAP user {username}");
                 error!("LDAP authentication failure: {err}");
-                Ok(AUTH_NOT_HANDLED)
+                if configs::get_return_auth_errors(ctx) {
+                    Err(ValkeyError::String(err.to_string()))
+                } else {
+                    Ok(AUTH_NOT_HANDLED)
+                }
             }
         }
     } else {
@@ -74,7 +78,11 @@ pub fn ldap_auth_blocking_callback(
         Ok(_) => Ok(AUTH_HANDLED),
         Err(err) => {
             error!("failed to submit ldap bind request: {err}");
-            Ok(AUTH_NOT_HANDLED)
+            if configs::get_return_auth_errors(ctx) {
+                Err(ValkeyError::String(err.to_string()))
+            } else {
+                Ok(AUTH_NOT_HANDLED)
+            }
         }
     }
 }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -106,6 +106,7 @@ lazy_static! {
     pub static ref LDAP_FAILURE_DETECTOR_INTERVAL: ValkeyGILGuard<i64> = ValkeyGILGuard::new(1);
     pub static ref LDAP_TIMEOUT_CONNECTION: ValkeyGILGuard<i64> = ValkeyGILGuard::new(10);
     pub static ref LDAP_TIMEOUT_LDAP_OPERATION: ValkeyGILGuard<i64> = ValkeyGILGuard::new(10);
+    pub static ref LDAP_RETURN_AUTH_ERRORS: ValkeyGILGuard<bool> = ValkeyGILGuard::default();
 }
 
 pub fn refresh_ldap_settings_cache<T: ValkeyLockIndicator>(ctx: &T) {
@@ -339,4 +340,9 @@ pub fn get_timeout_connection<T: ValkeyLockIndicator>(ctx: &T) -> Duration {
 pub fn get_timeout_ldap_operation<T: ValkeyLockIndicator>(ctx: &T) -> Duration {
     let timeout = LDAP_TIMEOUT_LDAP_OPERATION.lock(ctx);
     Duration::from_secs(*timeout as u64)
+}
+
+pub fn get_return_auth_errors<T: ValkeyLockIndicator>(ctx: &T) -> bool {
+    let return_errors = LDAP_RETURN_AUTH_ERRORS.lock(ctx);
+    *return_errors
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,13 @@ valkey_module! {
                 ConfigurationFlags::DEFAULT,
                 Some(Box::new(configs::on_connection_setting_change))
             ],
+            [
+                "return_auth_errors",
+                &*configs::LDAP_RETURN_AUTH_ERRORS,
+                false,
+                ConfigurationFlags::DEFAULT,
+                None
+            ],
         ],
         enum: [
             [

--- a/test/integration/test_ldap.py
+++ b/test/integration/test_ldap.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from threading import Thread
 from urllib.parse import urlparse
 
-from valkey.exceptions import AuthenticationError, ConnectionError
+from valkey.exceptions import AuthenticationError, ConnectionError, ResponseError
 import valkey
 
 from util import DOCKER_SERVICES, LdapTestCase, parse_valkey_info_section
@@ -69,6 +69,14 @@ class LdapModuleBindTest(LdapTestCase):
         with self.assertRaises(AuthenticationError) as ctx:
             self.vk.execute_command("AUTH", "user1", "wrongpass")
 
+    def test_ldap_return_auth_errors(self):
+        self.vk.execute_command("CONFIG", "SET", "ldap.return_auth_errors", "yes")
+
+        with self.assertRaises(ResponseError) as ctx:
+            self.vk.execute_command("AUTH", "user1", "wrongpass")
+
+        self.assertIn("bind operation", str(ctx.exception))
+
     def test_ldap_ssl_auth(self):
         self.vk.execute_command("CONFIG", "SET", "ldap.servers", "ldaps://ldap")
         self.vk.execute_command("AUTH", "user1", "user1@123")
@@ -121,6 +129,14 @@ class LdapModuleBindAndSearchTest(LdapTestCase):
         self.vk.execute_command("CONFIG", "SET", "ldap.servers", "ldaps://ldap")
         with self.assertRaises(AuthenticationError) as ctx:
             self.vk.execute_command("AUTH", "user2", "user2@123")
+
+    def test_ldap_return_auth_errors(self):
+        self.vk.execute_command("CONFIG", "SET", "ldap.return_auth_errors", "yes")
+
+        with self.assertRaises(ResponseError) as ctx:
+            self.vk.execute_command("AUTH", "u2", "wrongpass")
+
+        self.assertIn("bind operation", str(ctx.exception))
 
     def test_ldap_bind_password_hidden(self):
         res = self.vk.execute_command("CONFIG", "GET", "ldap.search_bind_passwd")

--- a/test/integration/util.py
+++ b/test/integration/util.py
@@ -65,6 +65,7 @@ class LdapTestCase(TestCase):
             "CONFIG", "SET", "ldap.tls_key_path", "/valkey-ldap/valkey-ldap-client.key"
         )
         vk.execute_command("CONFIG", "SET", "ldap.use_starttls", "no")
+        vk.execute_command("CONFIG", "SET", "ldap.return_auth_errors", "no")
 
         # Add users in Valkey
         vk.execute_command("ACL", "SETUSER", "user1", "ON", ">pass", "allcommands")


### PR DESCRIPTION
On a failed AUTH attempt from LDAP, AUTH is passed back to valkey-server which in turn returns the generic WRONGPASS error message. This improvement adds a config parameter ldap.return_auth_errors with a default value of "no" which maintains the current behaviour. When set to yes, the error from LDAP is passed and returned by valkey-server and no further auth attempts take place.

Resolves #57