### PR TITLE
add Rocky Linux 10 to package platforms

### DIFF
--- a/.github/package-platforms.json
+++ b/.github/package-platforms.json
@@ -57,7 +57,7 @@
     {
       "platform_id": "rockylinux-10",
       "family": "rhel",
-      "image": "rockylinux:10",
+      "image": "rockylinux/rockylinux:10",
       "arch": [
         "x86_64",
         "aarch64"

--- a/.github/package-platforms.json
+++ b/.github/package-platforms.json
@@ -55,6 +55,15 @@
       "arch": ["x86_64", "aarch64"]
     },
     {
+      "platform_id": "rockylinux-10",
+      "family": "rhel",
+      "image": "rockylinux:10",
+      "arch": [
+        "x86_64",
+        "aarch64"
+      ]
+    },
+    {
       "platform_id": "almalinux-8",
       "family": "rhel",
       "image": "almalinux:8",


### PR DESCRIPTION
#56 mentioned RPM packages are created for RockyLinux 8-10, but only 8 and 9 are available