### PR TITLE
remove Copr builds from packaging workflows

### DIFF
--- a/.github/workflows/nightly_packaging.yml
+++ b/.github/workflows/nightly_packaging.yml
@@ -31,62 +31,6 @@ jobs:
           fi
           echo "value=${VERSION}" >> $GITHUB_OUTPUT
 
-  Create_RPM_Package:
-    name: Create RPM (Copr)
-    needs: Get_GIT_SHA
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:44
-    steps:
-        - name: Checkout code
-          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-        - name: Install dependencies
-          shell: bash
-          env:
-            COPR_LOGIN: ${{ secrets.COPR_LOGIN }}
-            COPR_USERNAME: ${{ secrets.COPR_USERNAME }}
-            COPR_TOKEN: ${{ secrets.COPR_TOKEN }}
-          run: |
-            yum install -y copr-cli cargo rpmbuild jq git
-            cat <<EOF > copr.config
-            [copr-cli]
-            login = ${COPR_LOGIN}
-            username = ${COPR_USERNAME}
-            token = ${COPR_TOKEN}
-            copr_url = https://copr.fedorainfracloud.org
-            EOF
-
-        - name: Check previous nightly build
-          id: should_build
-          shell: bash
-          env:
-            GIT_SHA: ${{ needs.Get_GIT_SHA.outputs.sha }}
-          run: |
-            LAST_VERSION=`copr-cli --config copr.config get-package --name=valkey-ldap-nightly valkey-ldap | jq -r .latest_succeeded_build.source_package.version`
-            LAST_SHA=`echo $LAST_VERSION | sed 's/[0-9\.\~dev]\++\([0-9a-z]\+\)-1/\1/g'`
-            echo "LAST_SHA=${LAST_SHA}  GIT_SHA=${GIT_SHA}"
-            if [ "$LAST_SHA" != "$GIT_SHA" ]; then
-              echo "value=true" >> $GITHUB_OUTPUT
-            fi
-
-        - name: Vendoring dependencies
-          if: steps.should_build.outputs.value == 'true'
-          run: |
-            cargo vendor
-
-        - name: Build SRPM
-          if: steps.should_build.outputs.value == 'true'
-          env:
-            GIT_SHA: ${{ needs.Get_GIT_SHA.outputs.sha }}
-          run: |
-            ./packaging/build_srpm.sh $GIT_SHA
-
-        - name: Trigger Copr Build
-          if: steps.should_build.outputs.value == 'true'
-          run : |
-            SRPM=`ls valkey-ldap*.rpm`
-            copr-cli --config copr.config build valkey-ldap $SRPM
 
   Container_Packages:
     name: Container-based packages

--- a/.github/workflows/release_packaging.yml
+++ b/.github/workflows/release_packaging.yml
@@ -20,43 +20,6 @@ jobs:
           echo "value=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Release version: ${TAG}"
 
-  Create_RPM_Package:
-    name: Create RPM (Copr)
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:44
-    steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-
-        - name: Install dependencies
-          shell: bash
-          env:
-            COPR_LOGIN: ${{ secrets.COPR_LOGIN }}
-            COPR_USERNAME: ${{ secrets.COPR_USERNAME }}
-            COPR_TOKEN: ${{ secrets.COPR_TOKEN }}
-          run: |
-            yum install -y copr-cli cargo rpmbuild
-            cat <<EOF > copr.config
-            [copr-cli]
-            login = ${COPR_LOGIN}
-            username = ${COPR_USERNAME}
-            token = ${COPR_TOKEN}
-            copr_url = https://copr.fedorainfracloud.org
-            EOF
-
-        - name: Vendoring dependencies
-          run: |
-            cargo vendor
-
-        - name: Build SRPM
-          run: |
-            ./packaging/build_srpm.sh
-
-        - name: Trigger and wait for Copr Build
-          run : |
-            SRPM=`ls valkey-ldap*.rpm`
-            copr-cli --config copr.config build valkey-ldap $SRPM
 
   Container_Packages:
     name: Container-based packages

--- a/HOWTORELEASE.md
+++ b/HOWTORELEASE.md
@@ -23,7 +23,7 @@ These are the steps to make a release candidate for version `X.X.0`:
 8. Create a branch with name `X.X` and switch to that branch.
 8. Create an annotated tag for the above commit: `git tag -s -a X.X.0-rc1 -m"version X.X.0-rc1"`.
 9. Push commit and tag to github repo: `git push <remote> X.X --tags`
-   - This will trigger a GitHub action that triggers the RPMs build in Copr.
+   - This will trigger a GitHub action that builds the RPM and DEB packages.
 10. Switch back to the main branch.
 11. Update version string in `Cargo.toml` from `version = "X.X.0-rc1"` to `version = "Y.Y.0-dev"` where `Y.Y.0 > X.X.0`.
 12. Update version hex number in the unit test of `src/versions.rs`.
@@ -53,8 +53,8 @@ Assuming that version `X.X.0-rc1` has been cut of the main branch. To create the
 5. Create a commit with title `Bump to X.X.0` containing the modifications made in the previous steps.
 6. Create an annotated tag for the above commit: `git tag -s -a X.X.0 -m"version X.X.0"`.
 7. Push commit and tag to github repo: `git push <remote> X.X --tags`
-   - This will trigger a GitHub action that will create a draft release for version `X.X.0` and trigger the RPMs build in Copr.
+   - This will trigger a GitHub action that will create a draft release for version `X.X.0` and build the RPM and DEB packages.
 
 ## Steps for doing patch releases
 
-Same has the steps for releasing the GA version by increasing the patch version number of the version string.
+Same as the steps for releasing the GA version by increasing the patch version number of the version string.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# ValkeyLDAP - Valkey LDAP authentication module  ![CI](https://github.com/valkey-io/valkey-ldap/actions/workflows/ci.yml/badge.svg) [![Copr Build Status](https://copr.fedorainfracloud.org/coprs/rjd15372/valkey-ldap/package/valkey-ldap-nightly/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/rjd15372/valkey-ldap/package/valkey-ldap-nightly/)
+# ValkeyLDAP - Valkey LDAP authentication module  ![CI](https://github.com/valkey-io/valkey-ldap/actions/workflows/ci.yml/badge.svg)
 
 The `valkey-ldap` module is a Rust based Valkey module that adds the support for handling user authentication against LDAP based identity providers.
 
-The module works by registering and authentication handler that intercepts the valkey `AUTH` command, which validates the the username and password, specified in the `AUTH` command, using an LDAP server. Therefore the user must already exist in Valkey before LDAP can be used for authentication.
+The module works by registering an authentication handler that intercepts the valkey `AUTH` command, which validates the username and password, specified in the `AUTH` command, using an LDAP server. Therefore the user must already exist in Valkey before LDAP can be used for authentication.
 
 ## LDAP Authentication Modes
 
@@ -30,14 +30,14 @@ This mode allows for significantly more flexibility in where the user objects ar
 
 As mentioned before, this module requires that user accounts must exist in Valkey in order to authenticate LDAP users. This restriction is necessary because the ACL rules for each LDAP user are stored in the Valkey user account.
 
-For a user `bob` to be successfully authenticated by the LDAP module it must exist in the Valkey ALC database with the same username `bob`.
+For a user `bob` to be successfully authenticated by the LDAP module it must exist in the Valkey ACL database with the same username `bob`.
 
-We can create the Valkey user `bob` without a password, to prevent someone from trying to log in using `bob` account using the password-based authentication method.
+We can create the Valkey user `bob` without a password, to prevent someone from trying to log in using the `bob` account using the password-based authentication method.
 
 To create a user without a password we need to set the `resetpass` rule in the ACL rules list. Example:
 
 ```
-ACL SET USER bob on resetpass +@hash
+ACL SETUSER bob on resetpass +@hash
 ```
 
 After creating the above user `bob` in Valkey, it will only be possible to authenticate user `bob` with a successful authentication from the LDAP module.
@@ -56,7 +56,7 @@ After creating the above user `bob` in Valkey, it will only be possible to authe
 
 | Config Name | Type | Default | Description |
 | ------------|------|---------|-------------|
-| `ldap.use_starttls` | boolean | `no` | Whether upgrade to a TLS encrypted connection upon connection to a non-ssl LDAP instance. This uses the StartTLS operation per RFC 4513. |
+| `ldap.use_starttls` | boolean | `no` | Whether to upgrade to a TLS encrypted connection upon connection to a non-ssl LDAP instance. This uses the StartTLS operation per RFC 4513. |
 | `ldap.tls_ca_cert_path` | string | `""` | The filesystem path of the CA certificate for validating the server certificate in a TLS connection. |
 | `ldap.tls_cert_path` | string | `""` | The filesystem path of the client certificate to be used in a TLS connection to the LDAP server. |
 | `ldap.tls_key_path` | string | `""` | The filesystem path of the client certificate key to be used in a TLS connection to the LDAP server. |
@@ -86,12 +86,14 @@ After creating the above user `bob` in Valkey, it will only be possible to authe
 | ------------|------|---------|-------------|
 | `ldap.connection_pool_size` | number | `2` | The number of connections available in each LDAP server's connection pool. |
 | `ldap.failure_detector_interval` | number | `1` | The number of seconds between each iteration of the failure detector. |
-| `ldap.timeout_connection` | number | `10` | The number of seconds for to wait when connection to an LDAP server before timing out. |
-| `ldap.timeout_ldap_operation` | number | `10` | The number of seconds for to wait for an LDAP operation before timing out. |
+| `ldap.timeout_connection` | number | `10` | The number of seconds to wait when connecting to an LDAP server before timing out. |
+| `ldap.timeout_ldap_operation` | number | `10` | The number of seconds to wait for an LDAP operation before timing out. |
 
 ## Installation
 
-We currently build RPMs for several distributions in the [valkey-ldap Copr project](https://copr.fedorainfracloud.org/coprs/rjd15372/valkey-ldap/).
+RPM and DEB packages are built for several Linux distributions (Fedora, RHEL-compatible distributions, Amazon Linux, Debian, and Ubuntu) on both `x86_64` and `aarch64` by the [Build Packages](https://github.com/valkey-io/valkey-ldap/actions/workflows/packages.yml) GitHub workflow. Packages are built nightly from the `main` branch and for every release tag, and can be downloaded from the artifacts of the corresponding workflow run.
+
+Alternatively, the module can be built from source by following the [Build Instructions](#build-instructions) below. The resulting shared library is located at `target/debug/libvalkey_ldap.so` (or `target/release/libvalkey_ldap.so` when built with `cargo build --release`).
 
 ## Development
 


### PR DESCRIPTION
The container-based package builds in packages.yml replace the Copr RPM builds. Remove the Copr jobs from the nightly and release packaging workflows, drop the Copr badge and link from the README, and fix a few typos in README.md and HOWTORELEASE.md.